### PR TITLE
Add Claude Code plugin with migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Overstory wraps `sd` via `Bun.spawn(["sd", ...])` with `--json` parsing, identic
 | `claim(id)` | `sd update <id> --status=in_progress --json` |
 | `close(id, reason)` | `sd close <id> --reason "..." --json` |
 
+## Claude Code Plugin
+
+Seeds includes a [Claude Code plugin](claude-plugin/).
+
+```bash
+claude plugin install seeds@https://github.com/jayminwest/seeds
+```
+
+This provides the `/seeds:migrate-from-beads-to-seeds` command for automated migration from Beads to Seeds. See the [plugin README](claude-plugin/README.md) for details.
+
 ## Part of os-eco
 
 Seeds is part of the [os-eco](https://github.com/jayminwest/os-eco) AI agent tooling ecosystem.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+	"name": "seeds",
+	"description": "Claude Code plugin for Seeds git-native issue tracking",
+	"version": "0.1.0",
+	"author": {
+		"name": "jayminwest"
+	}
+}

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,20 @@
+# Seeds Claude Code Plugin
+
+Claude Code plugin for [Seeds](https://github.com/jayminwest/seeds) git-native issue tracking.
+
+## Install
+
+```bash
+claude plugin install seeds@https://github.com/jayminwest/seeds
+```
+
+Or load locally for development:
+
+```bash
+claude --plugin-dir ./claude-plugin
+```
+
+## Requirements
+
+- [Claude Code](https://claude.ai/download) CLI
+- [Seeds CLI](https://github.com/jayminwest/seeds) (`sd`)

--- a/claude-plugin/commands/migrate-from-beads-to-seeds/SKILL.md
+++ b/claude-plugin/commands/migrate-from-beads-to-seeds/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: seeds:migrate-from-beads-to-seeds
+description: Migrate a repository from Beads (bd) issue tracking to Seeds (sd). Initializes seeds, migrates issues, updates config files, and removes .beads/.
+---
+
+### 1. Verify Prerequisites
+
+Check that the current directory is a git repository:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null && echo "GIT_OK" || echo "NO_GIT"
+```
+
+If not a git repo, inform the user and stop:
+> This directory is not a git repository. Seeds requires git.
+
+Check that `.beads/` exists (nothing to migrate otherwise):
+```bash
+test -d .beads && echo "BEADS_EXISTS" || echo "NO_BEADS"
+```
+
+If `.beads/` does not exist, inform the user and stop:
+> No `.beads/` directory found. Nothing to migrate. Use `/dev:setup-seeds` to initialize seeds from scratch.
+
+Check that `.seeds/` does NOT already exist:
+```bash
+test -d .seeds && echo "SEEDS_EXISTS" || echo "NO_SEEDS"
+```
+
+If `.seeds/` already exists, inform the user and stop:
+> Seeds is already initialized. Use `sd list` to see existing issues.
+
+Check that the `sd` CLI is available:
+```bash
+sd --version 2>/dev/null || echo "SD_NOT_FOUND"
+```
+
+If `sd` is not found, inform the user and stop:
+> Seeds CLI (`sd`) is not installed. Install it with:
+> ```
+> npm install -g @os-eco/seeds-cli
+> ```
+> Note: Seeds requires the bun runtime. Install bun with `curl -fsSL https://bun.sh/install | bash` if needed.
+>
+> Then run `/seeds:migrate-from-beads-to-seeds` again.
+
+### 2. Initialize Seeds
+
+**IMPORTANT:** Seeds MUST be initialized before running the migration command. `sd migrate-from-beads` will fail without this step.
+
+```bash
+sd init
+```
+
+### 3. Migrate Issues
+
+Run the built-in migration command:
+```bash
+sd migrate-from-beads
+```
+
+This reads `.beads/issues.jsonl` and imports all issues into `.seeds/issues.jsonl`.
+
+### 4. Verify Migration
+
+Confirm issues were migrated:
+```bash
+sd list
+```
+
+Run health check:
+```bash
+sd doctor
+```
+
+If `sd doctor` reports any issues, fix them before proceeding. Re-run `sd doctor` until all checks pass.
+
+### 5. Update Config Files
+
+Run `sd onboard` to add the seeds section to CLAUDE.md:
+```bash
+sd onboard
+```
+
+Check if AGENTS.md exists and contains beads references:
+```bash
+test -f AGENTS.md && grep -l 'bd\|beads' AGENTS.md 2>/dev/null && echo "AGENTS_NEEDS_UPDATE" || echo "AGENTS_OK"
+```
+
+If AGENTS.md needs updating, use the Edit tool to replace all beads/bd references with seeds/sd equivalents:
+- `bd` commands become `sd` commands (e.g., `bd ready` -> `sd ready`, `bd sync` -> `sd sync`, `bd close` -> `sd close`)
+- "beads" becomes "seeds" in descriptions
+- "Beads" becomes "Seeds" in titles
+- `.beads/issues.jsonl` becomes `.seeds/issues.jsonl`
+
+Check if `.gitattributes` contains a beads merge driver line:
+```bash
+test -f .gitattributes && grep -c 'beads' .gitattributes 2>/dev/null && echo "GITATTRIBUTES_NEEDS_UPDATE" || echo "GITATTRIBUTES_OK"
+```
+
+If `.gitattributes` needs updating, use the Edit tool to remove the beads merge driver line (e.g., `.beads/issues.jsonl merge=beads`). Seeds adds its own lines via `sd init`, so only remove the beads-specific entries.
+
+### 6. Remove Beads
+
+Remove `.beads/` from git tracking. Use the `-rf` flag — the `-f` is required because export-state files are often modified:
+```bash
+git rm -rf .beads/
+```
+
+Remove remaining gitignored runtime files (database, daemon, socket):
+```bash
+rm -rf .beads/
+```
+
+### 7. Remove Beads Git Hooks
+
+Beads installs git hooks that delegate to `bd hook <name>`. These will block commits if `bd` finds no database. Check for and remove them:
+
+```bash
+grep -l 'bd hook\|bd hooks' .git/hooks/* 2>/dev/null
+```
+
+Remove every hook file that contains `bd hook` or `bd hooks`. Common ones are: `pre-commit`, `prepare-commit-msg`, `post-checkout`, `post-merge`, `pre-push`. Also remove any `.backup` files left by beads:
+
+```bash
+# Remove each beads hook found by the grep above, plus any .backup files
+rm -f .git/hooks/pre-commit .git/hooks/prepare-commit-msg .git/hooks/post-checkout .git/hooks/post-merge .git/hooks/pre-push
+rm -f .git/hooks/*.backup
+```
+
+**IMPORTANT:** Only remove hooks that contain `bd hook` or `bd hooks`. If a hook does NOT reference beads, leave it alone — it belongs to another tool.
+
+### 8. Commit
+
+Stage all changes and commit:
+```bash
+git add .seeds/ CLAUDE.md AGENTS.md .gitattributes
+git commit -m "Migrate from beads to seeds issue tracking"
+```
+
+### 9. Report Results
+
+Inform the user:
+
+> Migration complete. Summary:
+> - Issues migrated: [count from sd list]
+> - Seeds initialized in `.seeds/`
+> - CLAUDE.md updated with seeds onboard section
+> - AGENTS.md updated (if applicable)
+> - `.beads/` removed from repo
+>
+> You can now use:
+> - `sd ready` to see available work
+> - `sd create --title "..." --type task --priority 2` to create issues
+> - `sd sync` to sync with git


### PR DESCRIPTION
## Summary

- Adds a Claude Code plugin at `claude-plugin/` with the `/seeds:migrate-from-beads-to-seeds` slash command
- Updates main README to reference the plugin with install instructions
- Opens the door for future slash commands to ship alongside the CLI

Closes #1

## Test plan

- [x] `claude plugin validate ./claude-plugin` passes
- [x] `claude --plugin-dir ./claude-plugin` loads the plugin
- [x] `/seeds:migrate-from-beads-to-seeds` appears in the command list