### PR TITLE
feat: add comment support (sd comment add/list/delete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,10 @@ sd close <id> [<id2> ...]              Close one or more issues
 sd dep add <issue> <depends-on>        Add dependency
 sd dep remove <issue> <depends-on>     Remove dependency
 sd dep list <issue>                    Show deps for an issue
+sd comment add <issue-id> <body>        Add a comment to an issue
+  --author <name>                      (or set SEEDS_AUTHOR env var)
+sd comment list <issue-id>             List comments on an issue
+sd comment delete <issue-id> <cmt-id>  Delete a comment
 sd blocked                             Show all blocked issues
 sd stats                               Project statistics
 sd sync                                Stage and commit .seeds/ changes

--- a/src/commands/comment.test.ts
+++ b/src/commands/comment.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir: string;
+let issueId: string;
+
+const CLI = join(import.meta.dir, "../../src/index.ts");
+
+async function run(
+	args: string[],
+	cwd: string,
+	env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, ...env },
+	});
+	const stdout = await new Response(proc.stdout).text();
+	const stderr = await new Response(proc.stderr).text();
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
+async function runJson<T = unknown>(
+	args: string[],
+	cwd: string,
+	env?: Record<string, string>,
+): Promise<T> {
+	const { stdout } = await run([...args, "--json"], cwd, env);
+	return JSON.parse(stdout) as T;
+}
+
+beforeEach(async () => {
+	tmpDir = await mkdtemp(join(tmpdir(), "seeds-comment-test-"));
+	await run(["init"], tmpDir);
+
+	const result = await runJson<{ success: boolean; id: string }>(
+		["create", "--title", "Test issue for comments"],
+		tmpDir,
+	);
+	issueId = result.id;
+});
+
+afterEach(async () => {
+	await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("sd comment add", () => {
+	test("adds a comment to an issue", async () => {
+		const result = await runJson<{
+			success: boolean;
+			command: string;
+			issueId: string;
+			commentId: string;
+		}>(["comment", "add", issueId, "Hello world", "--author", "tester"], tmpDir);
+		expect(result.success).toBe(true);
+		expect(result.command).toBe("comment add");
+		expect(result.issueId).toBe(issueId);
+		expect(result.commentId).toMatch(/^c-/);
+	});
+
+	test("uses SEEDS_AUTHOR env var when --author not provided", async () => {
+		const result = await runJson<{ success: boolean; commentId: string }>(
+			["comment", "add", issueId, "Env author test"],
+			tmpDir,
+			{ SEEDS_AUTHOR: "env-user" },
+		);
+		expect(result.success).toBe(true);
+		expect(result.commentId).toMatch(/^c-/);
+	});
+
+	test("fails without author", async () => {
+		const { exitCode } = await run(["comment", "add", issueId, "No author"], tmpDir, {
+			SEEDS_AUTHOR: "",
+		});
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("fails with empty body", async () => {
+		const { exitCode } = await run(["comment", "add", issueId, "", "--author", "tester"], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("fails for nonexistent issue", async () => {
+		const { exitCode } = await run(
+			["comment", "add", "proj-ffff", "body", "--author", "tester"],
+			tmpDir,
+		);
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("comment appears in issue show output", async () => {
+		await run(["comment", "add", issueId, "Visible comment", "--author", "tester"], tmpDir);
+		const show = await runJson<{
+			success: boolean;
+			issue: { comments?: Array<{ id: string; author: string; body: string }> };
+		}>(["show", issueId], tmpDir);
+		expect(show.issue.comments).toHaveLength(1);
+		expect(show.issue.comments![0]!.author).toBe("tester");
+		expect(show.issue.comments![0]!.body).toBe("Visible comment");
+	});
+});
+
+describe("sd comment list", () => {
+	test("lists comments on an issue", async () => {
+		await run(["comment", "add", issueId, "First", "--author", "alice"], tmpDir);
+		await run(["comment", "add", issueId, "Second", "--author", "bob"], tmpDir);
+
+		const result = await runJson<{
+			success: boolean;
+			command: string;
+			issueId: string;
+			comments: Array<{ id: string; author: string; body: string }>;
+			count: number;
+		}>(["comment", "list", issueId], tmpDir);
+		expect(result.success).toBe(true);
+		expect(result.command).toBe("comment list");
+		expect(result.count).toBe(2);
+		expect(result.comments[0]!.author).toBe("alice");
+		expect(result.comments[0]!.body).toBe("First");
+		expect(result.comments[1]!.author).toBe("bob");
+		expect(result.comments[1]!.body).toBe("Second");
+	});
+
+	test("returns empty list for issue with no comments", async () => {
+		const result = await runJson<{ success: boolean; count: number; comments: unknown[] }>(
+			["comment", "list", issueId],
+			tmpDir,
+		);
+		expect(result.success).toBe(true);
+		expect(result.count).toBe(0);
+		expect(result.comments).toHaveLength(0);
+	});
+
+	test("fails for nonexistent issue", async () => {
+		const { exitCode } = await run(["comment", "list", "proj-ffff"], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+});
+
+describe("sd comment delete", () => {
+	let commentId: string;
+
+	beforeEach(async () => {
+		const result = await runJson<{ success: boolean; commentId: string }>(
+			["comment", "add", issueId, "To be deleted", "--author", "tester"],
+			tmpDir,
+		);
+		commentId = result.commentId;
+	});
+
+	test("deletes a comment", async () => {
+		const result = await runJson<{
+			success: boolean;
+			command: string;
+			issueId: string;
+			commentId: string;
+		}>(["comment", "delete", issueId, commentId], tmpDir);
+		expect(result.success).toBe(true);
+		expect(result.command).toBe("comment delete");
+		expect(result.commentId).toBe(commentId);
+	});
+
+	test("comment no longer appears after deletion", async () => {
+		await run(["comment", "delete", issueId, commentId], tmpDir);
+		const list = await runJson<{ success: boolean; count: number }>(
+			["comment", "list", issueId],
+			tmpDir,
+		);
+		expect(list.count).toBe(0);
+	});
+
+	test("fails for nonexistent comment", async () => {
+		const { exitCode } = await run(["comment", "delete", issueId, "c-ffff"], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("fails for nonexistent issue", async () => {
+		const { exitCode } = await run(["comment", "delete", "proj-ffff", commentId], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("updates issue updatedAt timestamp", async () => {
+		const before = await runJson<{ success: boolean; issue: { updatedAt: string } }>(
+			["show", issueId],
+			tmpDir,
+		);
+		// Small delay to ensure timestamp differs
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		await run(["comment", "delete", issueId, commentId], tmpDir);
+		const after = await runJson<{ success: boolean; issue: { updatedAt: string } }>(
+			["show", issueId],
+			tmpDir,
+		);
+		expect(after.issue.updatedAt).not.toBe(before.issue.updatedAt);
+	});
+});
+
+describe("sd comment (multiple operations)", () => {
+	test("add multiple then delete one leaves the other", async () => {
+		const c1 = await runJson<{ success: boolean; commentId: string }>(
+			["comment", "add", issueId, "Keep me", "--author", "alice"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; commentId: string }>(
+			["comment", "add", issueId, "Delete me", "--author", "bob"],
+			tmpDir,
+		);
+
+		await run(["comment", "delete", issueId, c2.commentId], tmpDir);
+
+		const list = await runJson<{
+			success: boolean;
+			comments: Array<{ id: string; body: string }>;
+			count: number;
+		}>(["comment", "list", issueId], tmpDir);
+		expect(list.count).toBe(1);
+		expect(list.comments[0]!.id).toBe(c1.commentId);
+		expect(list.comments[0]!.body).toBe("Keep me");
+	});
+});

--- a/src/commands/comment.test.ts
+++ b/src/commands/comment.test.ts
@@ -93,6 +93,28 @@ describe("sd comment add", () => {
 		expect(exitCode).not.toBe(0);
 	});
 
+	test("--json flag before body does not consume body as its value", async () => {
+		// Regression: old parseArgs() treated --json as a value flag, so
+		// `sd comment add PROJ --json "body"` would consume "body" as --json's value
+		// and then fail because the body positional was missing.
+		// Pass --json before the body to exercise this ordering.
+		const { stdout, exitCode } = await run(
+			["comment", "add", issueId, "--json", "my comment body", "--author", "tester"],
+			tmpDir,
+		);
+		expect(exitCode).toBe(0);
+		const result = JSON.parse(stdout) as { success: boolean; commentId: string };
+		expect(result.success).toBe(true);
+		// Verify the comment was stored with the correct body (not consumed by --json)
+		const list = await runJson<{
+			success: boolean;
+			comments: Array<{ id: string; body: string }>;
+			count: number;
+		}>(["comment", "list", issueId], tmpDir);
+		expect(list.count).toBe(1);
+		expect(list.comments[0]!.body).toBe("my comment body");
+	});
+
 	test("comment appears in issue show output", async () => {
 		await run(["comment", "add", issueId, "Visible comment", "--author", "tester"], tmpDir);
 		const show = await runJson<{

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -1,0 +1,204 @@
+import { Command } from "commander";
+import { findSeedsDir } from "../config.ts";
+import { generateId } from "../id.ts";
+import { accent, muted, outputJson, printSuccess } from "../output.ts";
+import { issuesPath, readIssues, withLock, writeIssues } from "../store.ts";
+import type { IssueComment } from "../types.ts";
+
+function parseArgs(args: string[]) {
+	const flags: Record<string, string | boolean> = {};
+	const positional: string[] = [];
+	let i = 0;
+	while (i < args.length) {
+		const arg = args[i];
+		if (!arg) {
+			i++;
+			continue;
+		}
+		if (arg.startsWith("--")) {
+			const key = arg.slice(2);
+			const eqIdx = key.indexOf("=");
+			if (eqIdx !== -1) {
+				flags[key.slice(0, eqIdx)] = key.slice(eqIdx + 1);
+				i++;
+			} else {
+				const next = args[i + 1];
+				if (next !== undefined && !next.startsWith("--")) {
+					flags[key] = next;
+					i += 2;
+				} else {
+					flags[key] = true;
+					i++;
+				}
+			}
+		} else {
+			positional.push(arg);
+			i++;
+		}
+	}
+	return { flags, positional };
+}
+
+export async function run(args: string[], seedsDir?: string): Promise<void> {
+	const jsonMode = args.includes("--json");
+	const { flags, positional } = parseArgs(args);
+	const subcmd = positional[0];
+
+	if (!subcmd) throw new Error("Usage: sd comment <add|list|delete> <issue-id> [...]");
+
+	const dir = seedsDir ?? (await findSeedsDir());
+
+	// sd comment add <issue-id> <body> [--author <name>]
+	if (subcmd === "add") {
+		const issueId = positional[1];
+		const body = positional[2];
+		if (!issueId) throw new Error("Usage: sd comment add <issue-id> <body> --author <name>");
+		if (!body || !body.trim()) throw new Error("Comment body is required");
+
+		const author =
+			typeof flags.author === "string" ? flags.author : (process.env.SEEDS_AUTHOR ?? "");
+		if (!author.trim()) {
+			throw new Error("--author is required (or set SEEDS_AUTHOR env var)");
+		}
+
+		let commentId = "";
+		await withLock(issuesPath(dir), async () => {
+			const issues = await readIssues(dir);
+			const idx = issues.findIndex((i) => i.id === issueId);
+			if (idx === -1) throw new Error(`Issue not found: ${issueId}`);
+
+			const issue = issues[idx]!;
+			const existingCommentIds = new Set((issue.comments ?? []).map((c) => c.id));
+			const id = generateId("c", existingCommentIds);
+			const now = new Date().toISOString();
+			const comment: IssueComment = { id, author, body: body.trim(), createdAt: now };
+
+			issues[idx] = {
+				...issue,
+				comments: [...(issue.comments ?? []), comment],
+				updatedAt: now,
+			};
+			commentId = id;
+			await writeIssues(dir, issues);
+		});
+
+		if (jsonMode) {
+			outputJson({ success: true, command: "comment add", issueId, commentId });
+		} else {
+			printSuccess(`Added comment ${commentId} to ${issueId}`);
+		}
+		return;
+	}
+
+	// sd comment list <issue-id>
+	if (subcmd === "list") {
+		const issueId = positional[1];
+		if (!issueId) throw new Error("Usage: sd comment list <issue-id>");
+
+		const issues = await readIssues(dir);
+		const issue = issues.find((i) => i.id === issueId);
+		if (!issue) throw new Error(`Issue not found: ${issueId}`);
+
+		const comments = issue.comments ?? [];
+
+		if (jsonMode) {
+			outputJson({
+				success: true,
+				command: "comment list",
+				issueId,
+				comments,
+				count: comments.length,
+			});
+		} else {
+			if (comments.length === 0) {
+				console.log("No comments.");
+				return;
+			}
+			console.log(
+				`${accent.bold(issueId)}  ${muted(`${comments.length} comment${comments.length === 1 ? "" : "s"}`)}`,
+			);
+			for (const comment of comments) {
+				console.log(
+					`\n${accent.bold(comment.id)}  ${muted(comment.author)}  ${muted(comment.createdAt)}`,
+				);
+				console.log(comment.body);
+			}
+		}
+		return;
+	}
+
+	// sd comment delete <issue-id> <comment-id>
+	if (subcmd === "delete") {
+		const issueId = positional[1];
+		const commentId = positional[2];
+		if (!issueId || !commentId) {
+			throw new Error("Usage: sd comment delete <issue-id> <comment-id>");
+		}
+
+		await withLock(issuesPath(dir), async () => {
+			const issues = await readIssues(dir);
+			const idx = issues.findIndex((i) => i.id === issueId);
+			if (idx === -1) throw new Error(`Issue not found: ${issueId}`);
+
+			const issue = issues[idx]!;
+			const comments = issue.comments ?? [];
+			const commentIdx = comments.findIndex((c) => c.id === commentId);
+			if (commentIdx === -1) throw new Error(`Comment not found: ${commentId}`);
+
+			const updated = comments.filter((c) => c.id !== commentId);
+			issues[idx] = {
+				...issue,
+				comments: updated.length > 0 ? updated : undefined,
+				updatedAt: new Date().toISOString(),
+			};
+			await writeIssues(dir, issues);
+		});
+
+		if (jsonMode) {
+			outputJson({ success: true, command: "comment delete", issueId, commentId });
+		} else {
+			printSuccess(`Deleted comment ${commentId} from ${issueId}`);
+		}
+		return;
+	}
+
+	throw new Error(`Unknown comment subcommand: ${subcmd}. Use add, list, or delete.`);
+}
+
+export function register(program: Command): void {
+	const comment = new Command("comment").description("Manage issue comments");
+
+	comment
+		.command("add <issue-id> <body>")
+		.description("Add a comment to an issue")
+		.option("--author <name>", "Comment author (or set SEEDS_AUTHOR env var)")
+		.option("--json", "Output as JSON")
+		.action(async (issueId: string, body: string, opts: { author?: string; json?: boolean }) => {
+			const args: string[] = ["add", issueId, body];
+			if (opts.author) args.push("--author", opts.author);
+			if (opts.json) args.push("--json");
+			await run(args);
+		});
+
+	comment
+		.command("list <issue-id>")
+		.description("List comments on an issue")
+		.option("--json", "Output as JSON")
+		.action(async (issueId: string, opts: { json?: boolean }) => {
+			const args: string[] = ["list", issueId];
+			if (opts.json) args.push("--json");
+			await run(args);
+		});
+
+	comment
+		.command("delete <issue-id> <comment-id>")
+		.description("Delete a comment")
+		.option("--json", "Output as JSON")
+		.action(async (issueId: string, commentId: string, opts: { json?: boolean }) => {
+			const args: string[] = ["delete", issueId, commentId];
+			if (opts.json) args.push("--json");
+			await run(args);
+		});
+
+	program.addCommand(comment);
+}

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -5,43 +5,21 @@ import { accent, muted, outputJson, printSuccess } from "../output.ts";
 import { issuesPath, readIssues, withLock, writeIssues } from "../store.ts";
 import type { IssueComment } from "../types.ts";
 
-function parseArgs(args: string[]) {
-	const flags: Record<string, string | boolean> = {};
-	const positional: string[] = [];
-	let i = 0;
-	while (i < args.length) {
-		const arg = args[i];
-		if (!arg) {
-			i++;
-			continue;
-		}
-		if (arg.startsWith("--")) {
-			const key = arg.slice(2);
-			const eqIdx = key.indexOf("=");
-			if (eqIdx !== -1) {
-				flags[key.slice(0, eqIdx)] = key.slice(eqIdx + 1);
-				i++;
-			} else {
-				const next = args[i + 1];
-				if (next !== undefined && !next.startsWith("--")) {
-					flags[key] = next;
-					i += 2;
-				} else {
-					flags[key] = true;
-					i++;
-				}
-			}
-		} else {
-			positional.push(arg);
-			i++;
-		}
-	}
-	return { flags, positional };
-}
-
 export async function run(args: string[], seedsDir?: string): Promise<void> {
 	const jsonMode = args.includes("--json");
-	const { flags, positional } = parseArgs(args);
+	const quietMode = args.includes("--quiet") || args.includes("-q");
+	// Collect positional args by skipping flags and their values.
+	// Value flags: --author. Boolean flags: --json, --quiet, -q.
+	const VALUE_FLAGS = new Set(["--author"]);
+	const positional: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i]!;
+		if (VALUE_FLAGS.has(a)) {
+			i++; // skip the flag's value
+		} else if (!a.startsWith("--") && a !== "-q") {
+			positional.push(a);
+		}
+	}
 	const subcmd = positional[0];
 
 	if (!subcmd) throw new Error("Usage: sd comment <add|list|delete> <issue-id> [...]");
@@ -55,8 +33,11 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 		if (!issueId) throw new Error("Usage: sd comment add <issue-id> <body> --author <name>");
 		if (!body || !body.trim()) throw new Error("Comment body is required");
 
+		const authorFlagIdx = args.indexOf("--author");
 		const author =
-			typeof flags.author === "string" ? flags.author : (process.env.SEEDS_AUTHOR ?? "");
+			authorFlagIdx !== -1 && args[authorFlagIdx + 1]
+				? args[authorFlagIdx + 1]!
+				: (process.env.SEEDS_AUTHOR ?? "");
 		if (!author.trim()) {
 			throw new Error("--author is required (or set SEEDS_AUTHOR env var)");
 		}
@@ -109,7 +90,7 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 				comments,
 				count: comments.length,
 			});
-		} else {
+		} else if (!quietMode) {
 			if (comments.length === 0) {
 				console.log("No comments.");
 				return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ async function registerAll(): Promise<void> {
 		import("./commands/onboard.ts"),
 		import("./commands/upgrade.ts"),
 		import("./commands/completions.ts"),
+		import("./commands/comment.ts"),
 	]);
 
 	for (const mod of mods) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -69,4 +69,14 @@ export function printIssueFull(issue: Issue): void {
 	console.log(`Created:  ${muted(issue.createdAt)}`);
 	console.log(`Updated:  ${muted(issue.updatedAt)}`);
 	if (issue.closedAt) console.log(`Closed:   ${muted(issue.closedAt)}`);
+
+	if (issue.comments && issue.comments.length > 0) {
+		console.log(`\n${muted(`Comments (${issue.comments.length}):`)}`);
+		for (const comment of issue.comments) {
+			console.log(
+				`\n${accent.bold(comment.id)}  ${muted(comment.author)}  ${muted(comment.createdAt)}`,
+			);
+			console.log(comment.body);
+		}
+	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,11 @@
+export interface IssueComment {
+	id: string;
+	author: string;
+	body: string;
+	createdAt: string;
+	updatedAt?: string;
+}
+
 export interface Issue {
 	id: string;
 	title: string;
@@ -10,6 +18,7 @@ export interface Issue {
 	blocks?: string[];
 	blockedBy?: string[];
 	convoy?: string;
+	comments?: IssueComment[];
 	createdAt: string;
 	updatedAt: string;
 	closedAt?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ export interface IssueComment {
 	author: string;
 	body: string;
 	createdAt: string;
-	updatedAt?: string;
 }
 
 export interface Issue {


### PR DESCRIPTION
## Summary

Expands Seeds functionality to include comments. 

See also PR#4 which enables comment importing and adds support for importing from Beads+Dolt implementations. 

- Adds `sd comment add/list/delete` subcommands for managing issue comments
- Comments stored inline on the issue object in JSONL, preserving the git-native single-file approach
- Includes `--author` flag with `SEEDS_AUTHOR` env var fallback, `--json` output on all subcommands

## Changes

- `src/types.ts`: Added `IssueComment` interface, `comments?: IssueComment[]` field on `Issue`
- `src/output.ts`: Comment rendering in `printIssueFull()` output
- `src/commands/comment.ts`: Full implementation (~170 lines) with add/list/delete
- `src/commands/comment.test.ts`: 15 integration tests (real I/O, temp directories)
- `src/index.ts`: Registered comment command in `registerAll()`
- `CLAUDE.md`: Added `sd comment` to CLI Command Reference

## Test plan

- [x] 15 automated integration tests covering CRUD, error paths, env var fallback
- [x] Manual testing: add/list/delete with human-readable and JSON output
- [x] Full test suite passes (209 tests, 0 failures)
- [x] Lint and typecheck clean