### PR TITLE
Add labels feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ seeds/
       update.ts               # sd update
       close.ts                # sd close
       dep.ts                  # sd dep add/remove/list
+      label.ts                # sd label add/remove/list/list-all
       sync.ts                 # sd sync
       blocked.ts              # sd blocked
       stats.ts                # sd stats
@@ -70,6 +71,7 @@ seeds/
       init.test.ts
       create.test.ts
       dep.test.ts
+      label.test.ts
       tpl.test.ts
       doctor.test.ts
       prime.test.ts
@@ -123,16 +125,23 @@ sd create --title <text>               Create a new issue
   --priority 0-4 or P0-P4             (default: 2)
   --description <text>
   --assignee <name>
+  --labels <labels>                    Comma-separated labels
 sd show <id>                           Show issue details
 sd list                                List issues with filters
   --status --type --assignee --limit
+  --label --label-any --unlabeled
 sd ready                               Open issues with no unresolved blockers
 sd update <id>                         Update issue fields
+  --add-label --remove-label --set-labels
 sd close <id> [<id2> ...]              Close one or more issues
   --reason <text>
 sd dep add <issue> <depends-on>        Add dependency
 sd dep remove <issue> <depends-on>     Remove dependency
 sd dep list <issue>                    Show deps for an issue
+sd label add <id...> <label>           Add label to issue(s)
+sd label remove <id...> <label>        Remove label from issue(s)
+sd label list <id>                     Show labels on an issue
+sd label list-all                      All unique labels with counts
 sd blocked                             Show all blocked issues
 sd stats                               Project statistics
 sd sync                                Stage and commit .seeds/ changes
@@ -214,6 +223,7 @@ interface Issue {
   priority: number;            // 0=critical, 1=high, 2=medium, 3=low, 4=backlog
   assignee?: string;
   description?: string;
+  labels?: string[];
   closeReason?: string;
   blocks?: string[];
   blockedBy?: string[];

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -71,6 +71,13 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 			: typeof flags.desc === "string"
 				? flags.desc
 				: undefined;
+	const labels =
+		typeof flags.labels === "string"
+			? flags.labels
+					.split(",")
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0)
+			: undefined;
 
 	const dir = seedsDir ?? (await findSeedsDir());
 	const config = await readConfig(dir);
@@ -91,6 +98,7 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 			updatedAt: now,
 			...(assignee ? { assignee } : {}),
 			...(description ? { description } : {}),
+			...(labels?.length ? { labels } : {}),
 		};
 		await appendIssue(dir, issue);
 		createdId = id;
@@ -113,6 +121,7 @@ export function register(program: Command): void {
 		.option("--assignee <name>", "Assignee name")
 		.option("--description <text>", "Issue description")
 		.option("--desc <text>", "Issue description (alias for --description)")
+		.option("--labels <labels>", "Comma-separated labels")
 		.option("--json", "Output as JSON")
 		.action(
 			async (opts: {
@@ -122,6 +131,7 @@ export function register(program: Command): void {
 				assignee?: string;
 				description?: string;
 				desc?: string;
+				labels?: string;
 				json?: boolean;
 			}) => {
 				const args: string[] = ["--title", opts.title];
@@ -130,6 +140,7 @@ export function register(program: Command): void {
 				if (opts.assignee) args.push("--assignee", opts.assignee);
 				if (opts.description) args.push("--description", opts.description);
 				if (opts.desc) args.push("--desc", opts.desc);
+				if (opts.labels) args.push("--labels", opts.labels);
 				if (opts.json) args.push("--json");
 				await run(args);
 			},

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -145,6 +145,17 @@ function checkSchemaValidation(seedsDir: string): DoctorCheck {
 		if (typeof issue.priority === "number" && (issue.priority < 0 || issue.priority > 4)) {
 			details.push(`${id}: invalid priority ${String(issue.priority)} (must be 0-4)`);
 		}
+		if (issue.labels !== undefined) {
+			if (!Array.isArray(issue.labels)) {
+				details.push(`${id}: labels is not an array`);
+			} else {
+				for (const [li, label] of issue.labels.entries()) {
+					if (typeof label !== "string" || label.trim().length === 0) {
+						details.push(`${id}: labels[${String(li)}] is not a non-empty string`);
+					}
+				}
+			}
+		}
 	}
 	if (details.length > 0) {
 		return {

--- a/src/commands/label.test.ts
+++ b/src/commands/label.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir: string;
+
+const CLI = join(import.meta.dir, "../../src/index.ts");
+
+async function run(
+	args: string[],
+	cwd: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stdout = await new Response(proc.stdout).text();
+	const stderr = await new Response(proc.stderr).text();
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
+async function runJson<T = unknown>(args: string[], cwd: string): Promise<T> {
+	const { stdout } = await run([...args, "--json"], cwd);
+	return JSON.parse(stdout) as T;
+}
+
+beforeEach(async () => {
+	tmpDir = await mkdtemp(join(tmpdir(), "seeds-label-test-"));
+	await run(["init"], tmpDir);
+});
+
+afterEach(async () => {
+	await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("sd label add", () => {
+	test("adds a label to an issue", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		const result = await runJson<{ success: boolean; command: string; label: string }>(
+			["label", "add", create.id, "bug"],
+			tmpDir,
+		);
+		expect(result.success).toBe(true);
+		expect(result.label).toBe("bug");
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug"]);
+	});
+
+	test("adds a label to multiple issues", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 1"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 2"],
+			tmpDir,
+		);
+		const result = await runJson<{ success: boolean; issueIds: string[]; label: string }>(
+			["label", "add", c1.id, c2.id, "urgent"],
+			tmpDir,
+		);
+		expect(result.success).toBe(true);
+		expect(result.issueIds).toEqual([c1.id, c2.id]);
+
+		const s1 = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", c1.id],
+			tmpDir,
+		);
+		const s2 = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", c2.id],
+			tmpDir,
+		);
+		expect(s1.issue.labels).toEqual(["urgent"]);
+		expect(s2.issue.labels).toEqual(["urgent"]);
+	});
+
+	test("deduplicates labels", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		await run(["label", "add", create.id, "bug"], tmpDir);
+		await run(["label", "add", create.id, "bug"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug"]);
+	});
+
+	test("fails for unknown issue", async () => {
+		const { exitCode } = await run(["label", "add", "proj-ffff", "bug"], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+
+	test("requires at least two positional args", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test"],
+			tmpDir,
+		);
+		const { exitCode } = await run(["label", "add", create.id], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+});
+
+describe("sd label remove", () => {
+	test("removes a label from an issue", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		await run(["label", "add", create.id, "bug"], tmpDir);
+		await run(["label", "add", create.id, "urgent"], tmpDir);
+
+		await run(["label", "remove", create.id, "bug"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["urgent"]);
+	});
+
+	test("cleans up empty labels to undefined", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		await run(["label", "add", create.id, "bug"], tmpDir);
+		await run(["label", "remove", create.id, "bug"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toBeUndefined();
+	});
+
+	test("removes label from multiple issues", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 1"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 2"],
+			tmpDir,
+		);
+		await run(["label", "add", c1.id, c2.id, "bug"], tmpDir);
+		await run(["label", "remove", c1.id, c2.id, "bug"], tmpDir);
+
+		const s1 = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", c1.id],
+			tmpDir,
+		);
+		const s2 = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", c2.id],
+			tmpDir,
+		);
+		expect(s1.issue.labels).toBeUndefined();
+		expect(s2.issue.labels).toBeUndefined();
+	});
+
+	test("removing a non-existent label succeeds silently", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		const { exitCode } = await run(["label", "remove", create.id, "nonexistent"], tmpDir);
+		expect(exitCode).toBe(0);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug", "urgent"]);
+	});
+});
+
+describe("sd label list", () => {
+	test("lists labels on an issue", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		await run(["label", "add", create.id, "bug"], tmpDir);
+		await run(["label", "add", create.id, "urgent"], tmpDir);
+
+		const result = await runJson<{ success: boolean; labels: string[] }>(
+			["label", "list", create.id],
+			tmpDir,
+		);
+		expect(result.success).toBe(true);
+		expect(result.labels).toEqual(["bug", "urgent"]);
+	});
+
+	test("returns empty array for issue with no labels", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		const result = await runJson<{ success: boolean; labels: string[] }>(
+			["label", "list", create.id],
+			tmpDir,
+		);
+		expect(result.labels).toEqual([]);
+	});
+
+	test("fails for unknown issue", async () => {
+		const { exitCode } = await run(["label", "list", "proj-ffff"], tmpDir);
+		expect(exitCode).not.toBe(0);
+	});
+});
+
+describe("sd label list-all", () => {
+	test("lists all labels across issues with counts", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 1"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 2"],
+			tmpDir,
+		);
+		await run(["label", "add", c1.id, "bug"], tmpDir);
+		await run(["label", "add", c1.id, "urgent"], tmpDir);
+		await run(["label", "add", c2.id, "bug"], tmpDir);
+
+		const result = await runJson<{
+			success: boolean;
+			labels: Array<{ label: string; count: number }>;
+		}>(["label", "list-all"], tmpDir);
+		expect(result.success).toBe(true);
+		expect(result.labels).toHaveLength(2);
+		// Sorted by count desc: bug=2, urgent=1
+		expect(result.labels[0]).toEqual({ label: "bug", count: 2 });
+		expect(result.labels[1]).toEqual({ label: "urgent", count: 1 });
+	});
+
+	test("includes labels from closed issues", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test issue"],
+			tmpDir,
+		);
+		await run(["label", "add", create.id, "archived"], tmpDir);
+		await run(["close", create.id], tmpDir);
+
+		const result = await runJson<{
+			success: boolean;
+			labels: Array<{ label: string; count: number }>;
+		}>(["label", "list-all"], tmpDir);
+		expect(result.labels).toHaveLength(1);
+		expect(result.labels[0]).toEqual({ label: "archived", count: 1 });
+	});
+
+	test("returns empty list when no labels exist", async () => {
+		await run(["create", "--title", "No labels"], tmpDir);
+		const result = await runJson<{
+			success: boolean;
+			labels: Array<{ label: string; count: number }>;
+		}>(["label", "list-all"], tmpDir);
+		expect(result.labels).toEqual([]);
+	});
+});
+
+describe("sd create --labels", () => {
+	test("creates issue with labels from comma-separated flag", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Labeled issue", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug", "urgent"]);
+	});
+
+	test("trims whitespace in comma-separated labels", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Labeled issue", "--labels", " bug , urgent "],
+			tmpDir,
+		);
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug", "urgent"]);
+	});
+
+	test("omits labels when not provided", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "No labels"],
+			tmpDir,
+		);
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toBeUndefined();
+	});
+});
+
+describe("sd update label flags", () => {
+	test("--add-label adds a label", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test"],
+			tmpDir,
+		);
+		await run(["update", create.id, "--add-label", "bug"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["bug"]);
+	});
+
+	test("--remove-label removes a label", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		await run(["update", create.id, "--remove-label", "bug"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["urgent"]);
+	});
+
+	test("--set-labels replaces all labels", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		await run(["update", create.id, "--set-labels", "feature,v2"], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toEqual(["feature", "v2"]);
+	});
+
+	test("--set-labels with empty string clears labels", async () => {
+		const create = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Test", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		await run(["update", create.id, "--set-labels", ""], tmpDir);
+
+		const show = await runJson<{ success: boolean; issue: { labels?: string[] } }>(
+			["show", create.id],
+			tmpDir,
+		);
+		expect(show.issue.labels).toBeUndefined();
+	});
+});
+
+describe("sd list label filters", () => {
+	test("--label filters with AND logic", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 1", "--labels", "bug,urgent"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 2", "--labels", "bug"],
+			tmpDir,
+		);
+
+		const result = await runJson<{
+			success: boolean;
+			issues: Array<{ id: string }>;
+			count: number;
+		}>(["list", "--label", "bug,urgent"], tmpDir);
+		expect(result.count).toBe(1);
+		expect(result.issues[0]?.id).toBe(c1.id);
+	});
+
+	test("--label-any filters with OR logic", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 1", "--labels", "bug"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 2", "--labels", "feature"],
+			tmpDir,
+		);
+		const c3 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Issue 3"],
+			tmpDir,
+		);
+
+		const result = await runJson<{
+			success: boolean;
+			issues: Array<{ id: string }>;
+			count: number;
+		}>(["list", "--label-any", "bug,feature"], tmpDir);
+		expect(result.count).toBe(2);
+		const ids = result.issues.map((i) => i.id);
+		expect(ids).toContain(c1.id);
+		expect(ids).toContain(c2.id);
+		expect(ids).not.toContain(c3.id);
+	});
+
+	test("--unlabeled shows only unlabeled issues", async () => {
+		const c1 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Labeled", "--labels", "bug"],
+			tmpDir,
+		);
+		const c2 = await runJson<{ success: boolean; id: string }>(
+			["create", "--title", "Unlabeled"],
+			tmpDir,
+		);
+
+		const result = await runJson<{
+			success: boolean;
+			issues: Array<{ id: string }>;
+			count: number;
+		}>(["list", "--unlabeled"], tmpDir);
+		expect(result.count).toBe(1);
+		expect(result.issues[0]?.id).toBe(c2.id);
+	});
+});

--- a/src/commands/label.ts
+++ b/src/commands/label.ts
@@ -1,0 +1,169 @@
+import { Command } from "commander";
+import { findSeedsDir } from "../config.ts";
+import { accent, muted, outputJson } from "../output.ts";
+import { issuesPath, readIssues, withLock, writeIssues } from "../store.ts";
+import type { Issue } from "../types.ts";
+
+function cleanLabels(labels: string[] | undefined): string[] | undefined {
+	if (!labels || labels.length === 0) return undefined;
+	return labels;
+}
+
+export async function run(args: string[], seedsDir?: string): Promise<void> {
+	const jsonMode = args.includes("--json");
+	const positional = args.filter((a) => !a.startsWith("--"));
+
+	const subcmd = positional[0];
+	if (!subcmd) throw new Error("Usage: sd label <add|remove|list|list-all>");
+
+	const dir = seedsDir ?? (await findSeedsDir());
+
+	if (subcmd === "list-all") {
+		const issues = await readIssues(dir);
+		const counts = new Map<string, number>();
+		for (const issue of issues) {
+			for (const label of issue.labels ?? []) {
+				counts.set(label, (counts.get(label) ?? 0) + 1);
+			}
+		}
+		const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+
+		if (jsonMode) {
+			const labels = sorted.map(([label, count]) => ({ label, count }));
+			outputJson({ success: true, command: "label list-all", labels });
+		} else {
+			if (sorted.length === 0) {
+				console.log("No labels found.");
+				return;
+			}
+			console.log(`${accent.bold("All Labels")}\n`);
+			for (const [label, count] of sorted) {
+				console.log(`  ${accent(label)} ${muted(`(${String(count)})`)}`);
+			}
+		}
+		return;
+	}
+
+	if (subcmd === "list") {
+		const issueId = positional[1];
+		if (!issueId) throw new Error("Usage: sd label list <issue>");
+		const issues = await readIssues(dir);
+		const issue = issues.find((i) => i.id === issueId);
+		if (!issue) throw new Error(`Issue not found: ${issueId}`);
+
+		const labels = issue.labels ?? [];
+
+		if (jsonMode) {
+			outputJson({ success: true, command: "label list", issueId, labels });
+		} else {
+			console.log(`${accent.bold(issueId)} ${muted("labels:")}`);
+			if (labels.length > 0) {
+				for (const label of labels) {
+					console.log(`  ${accent(label)}`);
+				}
+			} else {
+				console.log(muted("  No labels."));
+			}
+		}
+		return;
+	}
+
+	if (subcmd === "add" || subcmd === "remove") {
+		const rest = positional.slice(1);
+		if (rest.length < 2) {
+			throw new Error(`Usage: sd label ${subcmd} <issue-id...> <label>`);
+		}
+		const label = rest[rest.length - 1]!;
+		const issueIds = rest.slice(0, -1);
+
+		if (!label.trim()) {
+			throw new Error("Label cannot be empty");
+		}
+
+		await withLock(issuesPath(dir), async () => {
+			const issues = await readIssues(dir);
+
+			for (const issueId of issueIds) {
+				const idx = issues.findIndex((i) => i.id === issueId);
+				if (idx === -1) throw new Error(`Issue not found: ${issueId}`);
+
+				const issue = issues[idx]!;
+				const now = new Date().toISOString();
+
+				if (subcmd === "add") {
+					const labels = Array.from(new Set([...(issue.labels ?? []), label]));
+					issues[idx] = { ...issue, labels, updatedAt: now };
+				} else {
+					const labels = (issue.labels ?? []).filter((l) => l !== label);
+					issues[idx] = { ...issue, labels: cleanLabels(labels), updatedAt: now };
+				}
+			}
+
+			await writeIssues(dir, issues);
+		});
+
+		if (jsonMode) {
+			outputJson({
+				success: true,
+				command: `label ${subcmd}`,
+				issueIds,
+				label,
+			});
+		} else {
+			const verb = subcmd === "add" ? "Added" : "Removed";
+			const ids = issueIds.map((id) => accent(id)).join(", ");
+			console.log(
+				`${verb} label ${accent(label)} ${muted(subcmd === "add" ? "to" : "from")} ${ids}`,
+			);
+		}
+		return;
+	}
+
+	throw new Error(`Unknown label subcommand: ${subcmd}. Use add, remove, list, or list-all.`);
+}
+
+export function register(program: Command): void {
+	const label = new Command("label").description("Manage issue labels");
+
+	label
+		.command("add <args...>")
+		.description("Add a label to one or more issues (last arg = label)")
+		.option("--json", "Output as JSON")
+		.action(async (args: string[], opts: { json?: boolean }) => {
+			const runArgs: string[] = ["add", ...args];
+			if (opts.json) runArgs.push("--json");
+			await run(runArgs);
+		});
+
+	label
+		.command("remove <args...>")
+		.description("Remove a label from one or more issues (last arg = label)")
+		.option("--json", "Output as JSON")
+		.action(async (args: string[], opts: { json?: boolean }) => {
+			const runArgs: string[] = ["remove", ...args];
+			if (opts.json) runArgs.push("--json");
+			await run(runArgs);
+		});
+
+	label
+		.command("list <issue>")
+		.description("Show labels on an issue")
+		.option("--json", "Output as JSON")
+		.action(async (issue: string, opts: { json?: boolean }) => {
+			const runArgs: string[] = ["list", issue];
+			if (opts.json) runArgs.push("--json");
+			await run(runArgs);
+		});
+
+	label
+		.command("list-all")
+		.description("Show all unique labels across all issues with counts")
+		.option("--json", "Output as JSON")
+		.action(async (opts: { json?: boolean }) => {
+			const runArgs: string[] = ["list-all"];
+			if (opts.json) runArgs.push("--json");
+			await run(runArgs);
+		});
+
+	program.addCommand(label);
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -43,6 +43,21 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 	const statusFilter = typeof flags.status === "string" ? flags.status : undefined;
 	const typeFilter = typeof flags.type === "string" ? flags.type : undefined;
 	const assigneeFilter = typeof flags.assignee === "string" ? flags.assignee : undefined;
+	const labelAndFilter =
+		typeof flags.label === "string"
+			? flags.label
+					.split(",")
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0)
+			: undefined;
+	const labelOrFilter =
+		typeof flags["label-any"] === "string"
+			? flags["label-any"]
+					.split(",")
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0)
+			: undefined;
+	const noLabels = flags.unlabeled === true;
 	const showAll = flags.all === true;
 	const limitStr = typeof flags.limit === "string" ? flags.limit : "50";
 	const limit = Number.parseInt(limitStr, 10) || 50;
@@ -57,6 +72,21 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 	}
 	if (typeFilter) issues = issues.filter((i: Issue) => i.type === typeFilter);
 	if (assigneeFilter) issues = issues.filter((i: Issue) => i.assignee === assigneeFilter);
+	if (labelAndFilter && labelAndFilter.length > 0) {
+		issues = issues.filter((i: Issue) => {
+			const labels = i.labels ?? [];
+			return labelAndFilter.every((l) => labels.includes(l));
+		});
+	}
+	if (labelOrFilter && labelOrFilter.length > 0) {
+		issues = issues.filter((i: Issue) => {
+			const labels = i.labels ?? [];
+			return labelOrFilter.some((l) => labels.includes(l));
+		});
+	}
+	if (noLabels) {
+		issues = issues.filter((i: Issue) => !i.labels || i.labels.length === 0);
+	}
 
 	issues = issues.slice(0, limit);
 
@@ -82,6 +112,9 @@ export function register(program: Command): void {
 		.option("--type <type>", "Filter by type (task|bug|feature|epic)")
 		.option("--assignee <name>", "Filter by assignee")
 		.option("--all", "Include closed issues (default: only open/in_progress)")
+		.option("--label <labels>", "Filter by labels (comma-separated, AND logic)")
+		.option("--label-any <labels>", "Filter by labels (comma-separated, OR logic)")
+		.option("--unlabeled", "Show only issues without labels")
 		.option("--limit <n>", "Max issues to show", "50")
 		.option("--json", "Output as JSON")
 		.action(
@@ -90,6 +123,9 @@ export function register(program: Command): void {
 				type?: string;
 				assignee?: string;
 				all?: boolean;
+				label?: string;
+				labelAny?: string;
+				unlabeled?: boolean;
 				limit?: string;
 				json?: boolean;
 			}) => {
@@ -98,6 +134,9 @@ export function register(program: Command): void {
 				if (opts.type) args.push("--type", opts.type);
 				if (opts.assignee) args.push("--assignee", opts.assignee);
 				if (opts.all) args.push("--all");
+				if (opts.label) args.push("--label", opts.label);
+				if (opts.labelAny) args.push("--label-any", opts.labelAny);
+				if (opts.unlabeled) args.push("--unlabeled");
 				if (opts.limit) args.push("--limit", opts.limit);
 				if (opts.json) args.push("--json");
 				await run(args);

--- a/src/commands/prime.ts
+++ b/src/commands/prime.ts
@@ -22,6 +22,8 @@ sd create --title "..."   # Create issue (--type, --priority)
 sd update <id> --status in_progress  # Claim work
 sd close <id>             # Complete work
 sd dep add <a> <b>        # a depends on b
+sd label add <id> <label>  # Add label to issue
+sd label remove <id> <l>  # Remove label from issue
 sd blocked                # Show blocked issues
 sd sync                   # Stage + commit .seeds/
 \`\`\`
@@ -70,6 +72,17 @@ function fullContent(): string {
 - \`sd update <id> --assignee=username\` — Assign to someone
 - \`sd close <id>\` — Mark complete
 - \`sd close <id1> <id2> ...\` — Close multiple issues at once
+
+### Labels
+- \`sd label add <issue-id...> <label>\` — Add label to issue(s)
+- \`sd label remove <issue-id...> <label>\` — Remove label from issue(s)
+- \`sd label list <issue>\` — Show labels on an issue
+- \`sd label list-all\` — Show all labels with counts
+- \`sd create --labels="bug,urgent"\` — Set labels at creation
+- \`sd update <id> --add-label=bug\` — Add label via update
+- \`sd list --label=bug,urgent\` — Filter by labels (AND)
+- \`sd list --label-any=bug,feature\` — Filter by labels (OR)
+- \`sd list --unlabeled\` — Show unlabeled issues
 
 ### Dependencies & Blocking
 - \`sd dep add <issue> <depends-on>\` — Add dependency

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -32,11 +32,18 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 		byPriority[issue.priority] = (byPriority[issue.priority] ?? 0) + 1;
 	}
 
+	const byLabel: Record<string, number> = {};
+	for (const issue of issues) {
+		for (const label of issue.labels ?? []) {
+			byLabel[label] = (byLabel[label] ?? 0) + 1;
+		}
+	}
+
 	if (jsonMode) {
 		outputJson({
 			success: true,
 			command: "stats",
-			stats: { total, open, inProgress, closed, blocked, byType, byPriority },
+			stats: { total, open, inProgress, closed, blocked, byType, byPriority, byLabel },
 		});
 	} else {
 		console.log(`${chalk.bold("Project Statistics")}`);
@@ -54,6 +61,13 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 			for (const [p, count] of Object.entries(byPriority)) {
 				const label = PRIORITY_LABELS[Number(p)] ?? String(p);
 				console.log(`  ${muted(`P${p} ${label.padEnd(10)}`)} ${count}`);
+			}
+		}
+		if (Object.keys(byLabel).length > 0) {
+			console.log(`\n${chalk.bold("By Label")}`);
+			const sorted = Object.entries(byLabel).sort((a, b) => b[1] - a[1]);
+			for (const [label, count] of sorted) {
+				console.log(`  ${muted(label.padEnd(14))} ${count}`);
 			}
 		}
 	}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -85,6 +85,32 @@ export async function run(args: string[], seedsDir?: string): Promise<void> {
 			patch.priority = p;
 		}
 
+		// Label operations chain: set-labels first, then add-label, then remove-label.
+		// Each operates on the accumulated result so all flags can be combined.
+		let labelBase = issue.labels ?? [];
+
+		if (typeof flags["set-labels"] === "string") {
+			const val = flags["set-labels"];
+			if (val === "") {
+				labelBase = [];
+			} else {
+				const labels = val
+					.split(",")
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0);
+				labelBase = labels;
+			}
+			patch.labels = labelBase.length > 0 ? labelBase : undefined;
+		}
+		if (typeof flags["add-label"] === "string") {
+			labelBase = Array.from(new Set([...labelBase, flags["add-label"]]));
+			patch.labels = labelBase;
+		}
+		if (typeof flags["remove-label"] === "string") {
+			labelBase = labelBase.filter((l) => l !== flags["remove-label"]);
+			patch.labels = labelBase.length > 0 ? labelBase : undefined;
+		}
+
 		issues[idx] = { ...issue, ...patch };
 		updated = issues[idx];
 		await writeIssues(dir, issues);
@@ -108,6 +134,9 @@ export function register(program: Command): void {
 		.option("--desc <text>", "New description (alias for --description)")
 		.option("--type <type>", "New type (task|bug|feature|epic)")
 		.option("--priority <n>", "New priority 0-4 or P0-P4")
+		.option("--add-label <label>", "Add a label")
+		.option("--remove-label <label>", "Remove a label")
+		.option("--set-labels [labels]", "Set labels (comma-separated, empty to clear)")
 		.option("--json", "Output as JSON")
 		.action(
 			async (
@@ -120,6 +149,9 @@ export function register(program: Command): void {
 					desc?: string;
 					type?: string;
 					priority?: string;
+					addLabel?: string;
+					removeLabel?: string;
+					setLabels?: string | true;
 					json?: boolean;
 				},
 			) => {
@@ -131,6 +163,11 @@ export function register(program: Command): void {
 				if (opts.desc) args.push("--desc", opts.desc);
 				if (opts.type) args.push("--type", opts.type);
 				if (opts.priority) args.push("--priority", opts.priority);
+				if (opts.addLabel) args.push("--add-label", opts.addLabel);
+				if (opts.removeLabel) args.push("--remove-label", opts.removeLabel);
+				if (opts.setLabels !== undefined) {
+					args.push("--set-labels", opts.setLabels === true ? "" : opts.setLabels);
+				}
 				if (opts.json) args.push("--json");
 				await run(args);
 			},

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ async function registerAll(): Promise<void> {
 		import("./commands/update.ts"),
 		import("./commands/close.ts"),
 		import("./commands/dep.ts"),
+		import("./commands/label.ts"),
 		import("./commands/blocked.ts"),
 		import("./commands/stats.ts"),
 		import("./commands/sync.ts"),

--- a/src/output.ts
+++ b/src/output.ts
@@ -42,10 +42,14 @@ export function printIssueOneLine(issue: Issue): void {
 					? chalk.yellow("!")
 					: brand("-");
 	const priorityLabel = PRIORITY_LABELS[issue.priority] ?? String(issue.priority);
+	const labels =
+		issue.labels && issue.labels.length > 0
+			? ` ${chalk.magenta(`[${issue.labels.join(", ")}]`)}`
+			: "";
 	const assignee = issue.assignee ? ` · ${muted(`@${issue.assignee}`)}` : "";
 	const blocked = isBlocked ? ` ${chalk.yellow("[blocked]")}` : "";
 	console.log(
-		`${statusIcon} ${accent.bold(issue.id)} · ${issue.title}   ${muted(`[${priorityLabel} · ${issue.type}]`)}${assignee}${blocked}`,
+		`${statusIcon} ${accent.bold(issue.id)} · ${issue.title}   ${muted(`[${priorityLabel} · ${issue.type}]`)}${labels}${assignee}${blocked}`,
 	);
 }
 
@@ -59,6 +63,8 @@ export function printIssueFull(issue: Issue): void {
 	console.log(`Title:    ${issue.title}`);
 	console.log(`Type:     ${muted(issue.type)}   Priority: ${muted(priorityLabel)}`);
 	if (issue.assignee) console.log(`Assignee: ${issue.assignee}`);
+	if (issue.labels?.length)
+		console.log(`Labels:   ${issue.labels.map((l) => accent(l)).join(", ")}`);
 	if (issue.description) console.log(`\n${issue.description}`);
 	if (issue.blockedBy?.length)
 		console.log(`Blocked by: ${issue.blockedBy.map((id) => accent(id)).join(", ")}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Issue {
 	assignee?: string;
 	description?: string;
 	closeReason?: string;
+	labels?: string[];
 	blocks?: string[];
 	blockedBy?: string[];
 	convoy?: string;


### PR DESCRIPTION
## Summary
- Adds `labels` field to the Issue data model (`string[]`)
- New `sd label` subcommand: `add`, `remove`, `list`, `list-all`
- Label support in `sd create` (`--labels`), `sd update` (`--add-label`, `--remove-label`, `--set-labels`), and `sd list` (`--label`, `--label-any`, `--unlabeled`)
- Labels displayed in `sd show`, `sd list`, `sd stats`, and `sd prime` output
- Doctor validates label array integrity
- 436-line test suite covering all label operations

## Test plan
- [x] `bun test` — all tests pass including new label.test.ts
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)