### PR TITLE
fix(ci): force npm package manager for Polygraph/Nx indexing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,3 @@
+{
+  "cli": { "packageManager": "npm" }
+}


### PR DESCRIPTION
## Problem

Polygraph's repo indexer runs `nx init`, which auto-detects the package manager. Because this repo has `bun.lock` + `bunfig.toml`, Nx picks **bun** and runs `bun install` — but Polygraph's indexing container has node/npm and **no `bun`** on PATH, so indexing fails with `/bin/sh: 1: bun: not found`.

## Fix

Nx's `detectPackageManager` reads `nx.json` → `cli.packageManager` **before** any lockfile ([nx source](https://github.com/nrwl/nx/blob/master/packages/nx/src/utils/package-manager.ts)). Pinning `npm` makes the indexer use npm (available in the container) instead of bun. Single new file, **inert for real Bun workflows** — nothing here runs Nx locally and Bun ignores `nx.json`.

```json
{ "cli": { "packageManager": "npm" } }
```

## Validation

This exact fix was validated on **plot** ([PR #19](https://github.com/jayminwest/plot/pull/19)) — after merge, plot's indexing went green. This PR is part of the batch rolling it to the remaining five Bun repos.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a45930d460a55d2281a9567/sessions/fixing-indexing-ceb22558)
<!-- polygraph-session-end -->