### PR TITLE
fix(ci): remove nx.json (unblock Polygraph indexing)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,3 +1,0 @@
-{
-  "cli": { "packageManager": "npm" }
-}


### PR DESCRIPTION
## Problem

The earlier `nx.json` **breaks Polygraph indexing**: a committed `nx.json` makes the indexer treat the repo as already Nx-initialized, so it **skips `nx init`** (which installs the `nx` package). Indexing then dies with:

```
Error: Cannot find module 'nx/src/project-graph/project-graph'
code: 'MODULE_NOT_FOUND'
```

## Fix

Remove `nx.json`. Bun is now provided by Polygraph's setup script, so `nx init` runs on its own and installs `nx`. `nx.json` is an obsolete workaround.

Reverts the change from #104.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a45930d460a55d2281a9567/sessions/fixing-indexing-ceb22558)
<!-- polygraph-session-end -->